### PR TITLE
fix(ci): resolve 2 blocking issues preventing CI from passing

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -13,7 +13,7 @@ targets = [
 # The path where the advisory database is cloned/fetched into
 db-path = "~/.cargo/advisory-db"
 # Use the RustSec advisory database
-url = "https://github.com/rustsec/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
 # Check for yanked crates
 yanked = "warn"
 # Ignore specific advisories (keep this list minimal!)

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -12,7 +12,7 @@ use std::io::{self, Write};
 use std::time::{Duration, Instant};
 
 use crate::app::AppContext;
-use crate::auth::{self, JfpAuthClient, JfpAuthConfig, device_code, token_storage};
+use crate::auth::{JfpAuthClient, JfpAuthConfig, device_code, token_storage};
 use crate::cli::output::{HumanLayout, OutputFormat, emit_human, emit_json};
 use crate::error::{MsError, Result};
 


### PR DESCRIPTION
## Summary

- Remove unused `self` import in `auth.rs` (fixes cargo check with `-Dwarnings`)
- Update deprecated `url` → `db-urls` in `deny.toml` (fixes cargo-deny config)

## Context

The CI workflow has **0 successful runs out of 303** since January 16, 2026.

These two minimal changes should unblock the entire CI pipeline.

## Changes

| File | Change |
|------|--------|
| `src/cli/commands/auth.rs:15` | Remove unused `self` import |
| `deny.toml:16` | `url` → `db-urls` (cargo-deny breaking change) |

## Test plan

- [ ] CI Quick Check job passes
- [ ] CI Security Audit job passes
- [ ] Downstream jobs (Test, Lint, Coverage, MSRV) run and pass

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)