### PR TITLE
fix(search): escape user query for FTS5 MATCH

### DIFF
--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -526,6 +526,23 @@ impl Database {
     }
 
     pub fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<SkillSearchCandidate>> {
+        // Escape the user query into a safe FTS5 MATCH expression. Each
+        // whitespace-separated token becomes a double-quoted phrase (with
+        // embedded quotes doubled) so FTS5 syntax characters (`-`, `:`, `'`,
+        // `*`, `"`, parentheses) are treated as literal text rather than query
+        // operators. Without this, queries like "multi-agent" raise
+        // `no such column: agent` because FTS5 parses the `-` as an operator.
+        fn to_fts5_match_query(query: &str) -> String {
+            query
+                .split_whitespace()
+                .map(|token| format!("\"{}\"", token.replace('"', "\"\"")))
+                .collect::<Vec<_>>()
+                .join(" ")
+        }
+        let match_query = to_fts5_match_query(query);
+        if match_query.is_empty() {
+            return Ok(Vec::new());
+        }
         let mut stmt = self.conn.prepare(
             "SELECT s.id, s.source_layer, s.metadata_json, s.quality_score, s.is_deprecated
              FROM skills_fts f
@@ -534,7 +551,7 @@ impl Database {
              ORDER BY bm25(skills_fts)
              LIMIT ?",
         )?;
-        let rows = stmt.query_map(params![query, limit as i64], |row| {
+        let rows = stmt.query_map(params![match_query, limit as i64], |row| {
             Ok(SkillSearchCandidate {
                 id: row.get(0)?,
                 source_layer: row.get(1)?,
@@ -1820,6 +1837,59 @@ mod tests {
         assert_eq!(results[0].id, "rust-errors");
         assert_eq!(results[0].quality_score, 0.9);
         assert!(!results[0].is_deprecated);
+    }
+
+    #[test]
+    fn test_fts_search_special_characters() {
+        // Queries containing FTS5 syntax characters must be treated as literal
+        // search terms, not query operators. Before escaping, "multi-agent"
+        // raised `no such column: agent` and a bare `'` raised an fts5 syntax
+        // error. Each of these must now return Ok without panicking.
+        let dir = tempdir().unwrap();
+        let db = Database::open(dir.path().join("test.db")).unwrap();
+        let record = SkillRecord {
+            id: "agent-swarm".to_string(),
+            name: "Agent Swarm Launcher".to_string(),
+            description: "Coordinate a multi-agent swarm".to_string(),
+            version: Some("1.0.0".to_string()),
+            author: None,
+            source_path: "/skills/swarm".to_string(),
+            source_layer: "base".to_string(),
+            git_remote: None,
+            git_commit: None,
+            content_hash: "abc123".to_string(),
+            body: "Launch a multi-agent swarm and coordinate work".to_string(),
+            metadata_json: r#"{"tags":"multi-agent,swarm"}"#.to_string(),
+            assets_json: "{}".to_string(),
+            token_count: 100,
+            quality_score: 0.8,
+            indexed_at: "2026-01-01T00:00:00Z".to_string(),
+            modified_at: "2026-01-01T00:00:00Z".to_string(),
+            is_deprecated: false,
+            deprecation_reason: None,
+        };
+        db.upsert_skill(&record).unwrap();
+
+        // None of these may error.
+        for query in [
+            "multi-agent",
+            "a-b",
+            "x-y-z",
+            "a'b",
+            "agent: swarm",
+            "(swarm)",
+        ] {
+            db.search_fts(query, 10)
+                .unwrap_or_else(|e| panic!("query {query:?} should not error: {e}"));
+        }
+
+        // The hyphenated phrase must still find the matching skill.
+        let results = db.search_fts("multi-agent", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "agent-swarm");
+
+        // A blank / whitespace-only query yields no results rather than erroring.
+        assert!(db.search_fts("   ", 10).unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`Database::search_fts` binds the raw user query directly into `skills_fts MATCH ?`. SQLite's FTS5 parser then interprets syntax characters in the query as operators rather than literal text, so ordinary searches error:

```
$ ms search "multi-agent"
Error: Database error: no such column: agent
```

Minimal reproduction (any FTS5 build):

| Query | Result |
|-------|--------|
| `multi-agent` | `no such column: agent` (FTS5 parses `-` as an operator) |
| `a-b` | `no such column: b` |
| `a'b` | `fts5: syntax error near "'"` |
| `"multi-agent"` | works (quoted phrase) |

This affects `ms search` and the MCP `search`/`suggest` tools, which share this code path. Hyphenated terms are common in skill names (e.g. `agent-swarm-launcher`, `multi-agent`).

## Fix

Escape the query into a safe FTS5 MATCH expression before binding: each whitespace-separated token becomes a double-quoted phrase (with embedded `"` doubled), so `-`, `:`, `'`, `*`, `"`, and parentheses are treated as literal text. Multi-token queries keep their implicit-AND behavior. Blank/whitespace-only queries now return no results instead of erroring on an empty MATCH expression.

The change is contained to `search_fts`, so both the CLI and MCP paths are fixed in one place.

## Testing

- New regression test `test_fts_search_special_characters` covers hyphens, quotes, colons, and parentheses, and asserts a hyphenated phrase still matches.
- `cargo test --lib storage::sqlite::tests` — both FTS tests pass.
- Verified live against a real index: `ms search "multi-agent"` now returns results; `a-b` / `a'b` return gracefully instead of erroring.

## Review focus

- Token-quoting in `to_fts5_match_query` (quote-doubling for embedded `"`).
- Behavior tradeoff: trailing-`*` prefix queries are now treated as literal `*`. If prefix search is a supported feature, that would need separate handling.